### PR TITLE
Update dumper.php - ignore 'views'

### DIFF
--- a/dumper.php
+++ b/dumper.php
@@ -224,9 +224,11 @@ abstract class Shuttle_Dumper {
 		if (!empty($this->include_tables)) {
 			return $this->include_tables;
 		}
-
+		
+		// $tables will only include the tables and not views.
+		// TODO - Handle views also, edits to be made in function 'get_create_table_sql' line 336
 		$tables = $this->db->fetch_numeric('
-			SHOW TABLES LIKE "' . $this->db->escape_like($table_prefix) . '%"
+			SHOW FULL TABLES WHERE Table_Type = "BASE TABLE" AND Tables_in_'.$this->db->name.' LIKE "' . $this->db->escape_like($table_prefix) . '%"
 		');
 
 		$tables_list = array();


### PR DESCRIPTION
All the table names are being fetched using SQL query that also returns VIEWS in the database.
Subsequent code is not equipped to handles the views hence causing errors.
Simply changed the query to only return Tables.
TODO - add code to handle views to create a "complete database dump"