### PR TITLE
fixed: exporting records that contain utf8 content

### DIFF
--- a/src/Dump_File/Plaintext.php
+++ b/src/Dump_File/Plaintext.php
@@ -9,6 +9,7 @@ class Plaintext extends Dump_File {
 		return fopen($this->file_location, 'w');
 	}
 	function write($string) {
+		$string="\xEF\xBB\xBF".$string;
 		return fwrite($this->fh, $string);
 	}
 	function end() {


### PR DESCRIPTION
As the UTF-8 byte-order mark is \xef\xbb\xbf we should add it to the document's header.
https://stackoverflow.com/questions/6336586/fwrite-and-utf8